### PR TITLE
finish ios project deletion

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		CEB7E56F2BF8C964002337B7 /* TaskInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7E56E2BF8C964002337B7 /* TaskInfoViewModel.swift */; };
 		CEC085FC2BF79B3800BBBEC2 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC085FB2BF79B3800BBBEC2 /* Extensions.swift */; };
 		CEC085FE2BF7DFA900BBBEC2 /* TaskInfoProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC085FD2BF7DFA900BBBEC2 /* TaskInfoProtocol.swift */; };
+		CEC6010A2BFDFD280016DC0F /* TemplateCreationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC601092BFDFD280016DC0F /* TemplateCreationAlert.swift */; };
 		CED37B322BFCF4FC00F9629D /* ViewModelProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED37B312BFCF4FC00F9629D /* ViewModelProtocols.swift */; };
 		CED37B352BFCFC0500F9629D /* ProjectListNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED37B342BFCFC0500F9629D /* ProjectListNavBar.swift */; };
 		CED37B372BFCFC8500F9629D /* TaskListNavBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED37B362BFCFC8500F9629D /* TaskListNavBar.swift */; };
@@ -203,6 +204,7 @@
 		CEB7E56E2BF8C964002337B7 /* TaskInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInfoViewModel.swift; sourceTree = "<group>"; };
 		CEC085FB2BF79B3800BBBEC2 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		CEC085FD2BF7DFA900BBBEC2 /* TaskInfoProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInfoProtocol.swift; sourceTree = "<group>"; };
+		CEC601092BFDFD280016DC0F /* TemplateCreationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateCreationAlert.swift; sourceTree = "<group>"; };
 		CED37B312BFCF4FC00F9629D /* ViewModelProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelProtocols.swift; sourceTree = "<group>"; };
 		CED37B342BFCFC0500F9629D /* ProjectListNavBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectListNavBar.swift; sourceTree = "<group>"; };
 		CED37B362BFCFC8500F9629D /* TaskListNavBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskListNavBar.swift; sourceTree = "<group>"; };
@@ -524,6 +526,7 @@
 		289BFD372BD1914C00099EAE /* ModalScreens */ = {
 			isa = PBXGroup;
 			children = (
+				CEC601082BFDFD000016DC0F /* CreationAlerts */,
 			);
 			path = ModalScreens;
 			sourceTree = "<group>";
@@ -686,6 +689,14 @@
 			path = Helpers;
 			sourceTree = "<group>";
 		};
+		CEC601082BFDFD000016DC0F /* CreationAlerts */ = {
+			isa = PBXGroup;
+			children = (
+				CEC601092BFDFD280016DC0F /* TemplateCreationAlert.swift */,
+			);
+			path = CreationAlerts;
+			sourceTree = "<group>";
+		};
 		CED37B302BFCF4B200F9629D /* Protocols */ = {
 			isa = PBXGroup;
 			children = (
@@ -833,6 +844,7 @@
 				28609D042BD15A42005D2D01 /* ScreenInfoButton.swift in Sources */,
 				2864E6AE2BD38F7600504DE0 /* TaskCardsProtocols.swift in Sources */,
 				28DE0A3B2BCEE7C3001F819C /* TemplateActionButton.swift in Sources */,
+				CEC6010A2BFDFD280016DC0F /* TemplateCreationAlert.swift in Sources */,
 				CED37B352BFCFC0500F9629D /* ProjectListNavBar.swift in Sources */,
 				289BFD2F2BD18F5F00099EAE /* ActionButtonsConstants.swift in Sources */,
 				CED37B3B2BFD1E8E00F9629D /* ProjectCreationAlert.swift in Sources */,

--- a/iosApp/iosApp/Helpers/Protocols/ViewModelProtocols.swift
+++ b/iosApp/iosApp/Helpers/Protocols/ViewModelProtocols.swift
@@ -6,6 +6,10 @@
 //  Copyright © 2024 TaskMaster. All rights reserved.
 //
 
+protocol TaskCardViewModelProtocol {
+    func deleteCard(_ id: UInt16) async
+}
+
 protocol Searchable {
     func search() async
 }

--- a/iosApp/iosApp/UI/Components/Protocols.swift
+++ b/iosApp/iosApp/UI/Components/Protocols.swift
@@ -11,5 +11,5 @@ protocol Openable {
 }
 
 protocol Removable {
-    func remove()
+    func remove() async
 }

--- a/iosApp/iosApp/UI/Components/Views/NavBars/ProjectListNavBar.swift
+++ b/iosApp/iosApp/UI/Components/Views/NavBars/ProjectListNavBar.swift
@@ -38,8 +38,17 @@ struct ProjectListNavBar<Content: View>: View {
             Label("Добавить пользователя", systemImage: "person.crop.circle.badge.plus")
         }
 
+        Button(action: {}) {
+            Label("Удалить пользователя", systemImage: "person.crop.circle.badge.minus")
+        }
+
         Button(action: { alertManager.addProjectState.toggle() }) {
             Label("Добавить проект", systemImage: "plus.rectangle.on.rectangle")
+        }
+
+        Button(role: .destructive, action: {}) {
+            Label("Выйти", systemImage: "rectangle.portrait.and.arrow.right")
+                .tint(Color(uiColor: .systemPink))
         }
     }
 }

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/TaskCardsProtocols.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/TaskCardsProtocols.swift
@@ -12,7 +12,7 @@ protocol TaskCardActions: Openable & Removable {}
 protocol CardInfoProtocol {
     var model: any TaskInfoProtocol { get }
 
-    init(model: any TaskInfoProtocol)
+    init(model: any TaskInfoProtocol, viewModel: TaskCardViewModelProtocol)
 }
 
 protocol TaskTitleProvider: CardInfoProtocol {

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardController.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardController.swift
@@ -6,17 +6,25 @@
 //  Copyright © 2024 TaskMaster. All rights reserved.
 //
 
+import SwiftUI
+
 final class ProjectCardController: ProjectCardControllerProtocol {
     //    MARK: Props
+    private var viewModel: TaskCardViewModelProtocol
     let model: any TaskInfoProtocol
 
     //    MARK: Init
-    required init(model: any TaskInfoProtocol) {
+    required init(model: any TaskInfoProtocol, viewModel: TaskCardViewModelProtocol) {
         self.model = model
+        self.viewModel = viewModel
     }
 
     //    MARK: Methods
     func open() {}
 
-    func remove() {}
+    func remove() async {
+        Task {
+            await viewModel.deleteCard(model.id)
+        }
+    }
 }

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardView.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardView.swift
@@ -13,8 +13,8 @@ struct ProjectCardView: View {
     private let controller: ProjectCardControllerProtocol
 
     //    MARK: Init
-    init(model: ProjectInfo) {
-        controller = ProjectCardController(model: model)
+    init(model: ProjectInfo, viewModel: ProjectListViewModelProtocol) {
+        controller = ProjectCardController(model: model, viewModel: viewModel)
     }
 
     //    MARK: Body
@@ -33,10 +33,6 @@ struct ProjectCardView: View {
                 .multilineTextAlignment(.leading)
 
             Spacer()
-
-//            if controller.isUrgent {
-//                Image(systemName: controller.urgentImageName)
-//            }
         }
 
         Text(controller.participiantsTitle)

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardController.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardController.swift
@@ -8,11 +8,13 @@
 
 final class SubTaskCardController: SubTaskCardControllerProtocol {
     //    MARK: Props
+    private let viewModel: TaskCardViewModelProtocol
     let model: any TaskInfoProtocol
 
     //    MARK: Init
-    required init(model: any TaskInfoProtocol) {
+    required init(model: any TaskInfoProtocol, viewModel: TaskCardViewModelProtocol) {
         self.model = model
+        self.viewModel = viewModel
     }
 
     //    MARK: Methods

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardView.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardView.swift
@@ -13,8 +13,8 @@ struct SubTaskCardView: View {
     private let controller: SubTaskCardControllerProtocol
 
     //    MARK: Init
-    init(model: TaskInfo) {
-        controller = SubTaskCardController(model: model)
+    init(model: TaskInfo, viewModel: TaskCardViewModelProtocol) {
+        controller = SubTaskCardController(model: model, viewModel: viewModel)
     }
 
     //    MARK: Body

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardController.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardController.swift
@@ -9,10 +9,12 @@
 final class TaskCardController: TaskCardControllerProtocol {
     //    MARK: Props
     let model: any TaskInfoProtocol
+    private let viewModel: TaskCardViewModelProtocol
 
     //    MARK: Init
-    required init(model: any TaskInfoProtocol) {
+    init(model: any TaskInfoProtocol, viewModel: TaskCardViewModelProtocol) {
         self.model = model
+        self.viewModel = viewModel
     }
 
     //    MARK: Methods

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardView.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardView.swift
@@ -21,8 +21,8 @@ struct TaskCardView: View {
     }
 
     /// Initializes the view with default realization.
-    init(model: TaskInfo) {
-        controller = TaskCardController(model: model)
+    init(model: TaskInfo, viewModel: TaskCardViewModelProtocol) {
+        controller = TaskCardController(model: model, viewModel: viewModel)
     }
 
     //    MARK: Body
@@ -32,8 +32,8 @@ struct TaskCardView: View {
 
     @ViewBuilder
     private var ViewBody: some View {
-//        Text(controller.taskNumberTitle)
-//            .font(.footnote)
+        //        Text(controller.taskNumberTitle)
+        //            .font(.footnote)
 
         Text(controller.taskTitle)
             .multilineTextAlignment(.leading)
@@ -45,9 +45,9 @@ struct TaskCardView: View {
 
             Spacer()
 
-//            if controller.isUrgent {
-//                Image(systemName: controller.urgentImageName)
-//            }
+            //            if controller.isUrgent {
+            //                Image(systemName: controller.urgentImageName)
+            //            }
         }
 
         Text(controller.participiantsTitle)

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TemplateTaskCardView.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TemplateTaskCardView.swift
@@ -12,7 +12,6 @@ struct TemplateTaskCardView<Content: View>: View {
     //    MARK: Props
     private let controller: TaskCardActions
     @ViewBuilder private let content: () -> Content
-    @State private var isButtonVisible = true
 
     //    MARK: Init
     init(controller: TaskCardActions, @ViewBuilder content: @escaping () -> Content) {
@@ -27,35 +26,27 @@ struct TemplateTaskCardView<Content: View>: View {
 
     private var ViewBody: some View {
         VStack {
-            if isButtonVisible {
-//                Button(action: controller.open) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: TaskCardsConstants.Numbers.lineSpacing) {
-                            content()
-                        }
+            HStack {
+                VStack(alignment: .leading, spacing: TaskCardsConstants.Numbers.lineSpacing) {
+                    content()
+                }
 
-                        Spacer()
-                    }
-//                }
-                .padding()
-                .background(
-                    Color(uiColor: .secondarySystemBackground),
-                    in: RoundedRectangle(cornerRadius: 8, style: .continuous)
-                )
-                .transition(.move(edge: .trailing))
-                .animation(.easeInOut)
+                Spacer()
+            }
+            .padding()
+            .background(
+                Color(uiColor: .secondarySystemBackground),
+                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+            )
+        }
+        .contextMenu {
+            Button(
+                action: {
+                    Task { await controller.remove() }
+                }
+            ) {
+                Label("Удалить", systemImage: "trash.square")
             }
         }
-        .gesture(
-            DragGesture()
-                .onEnded { value in
-                    if value.translation.width < -100 {
-                        withAnimation {
-                            isButtonVisible = false
-                            controller.remove()
-                        }
-                    }
-                }
-        )
     }
 }

--- a/iosApp/iosApp/UI/ModalScreens/CreationAlerts/TemplateCreationAlert.swift
+++ b/iosApp/iosApp/UI/ModalScreens/CreationAlerts/TemplateCreationAlert.swift
@@ -1,0 +1,50 @@
+//
+//  TemplateCreationAlert.swift
+//  TaskMaster
+//
+//  Created by  user on 22-05-2024.
+//  Copyright © 2024 TaskMaster. All rights reserved.
+//
+
+import SwiftUI
+
+struct TemplateCreationAlert<Content: View>: View {
+    @ViewBuilder private let content: () -> Content
+    private let title: String
+    private let action: () -> Void
+
+    init(_ title: String, @ViewBuilder content: @escaping () -> Content, action: @escaping () -> Void) {
+        self.title = title
+        self.content = content
+        self.action = action
+    }
+
+    var body: some View {
+        VStack {
+            VStack(spacing: 64) {
+                VStack {
+                    content()
+                }
+
+                VStack {
+                    Divider().background(.secondary)
+
+                    Button(action: action) {
+                        Text(title)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .padding(.horizontal)
+                            .foregroundColor(.white)
+                            .background(.tint,
+                                        in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    }
+                }
+            }
+            .padding()
+            .background(
+                Color(uiColor: .secondarySystemBackground),
+                in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+            )
+        }
+    }
+}

--- a/iosApp/iosApp/UI/Screens/ProjectList/ProjectCreationAlert.swift
+++ b/iosApp/iosApp/UI/Screens/ProjectList/ProjectCreationAlert.swift
@@ -19,15 +19,26 @@ struct ProjectCreationAlert: View {
     }
 
     var body: some View {
-        VStack {
-            TextField("Название проекта", text: $text)
-
-            Button("Создать проект") {
-                Task {
-                    await viewModel.createProject(text)
-                    alertManager.addProjectState.toggle()
-                }
-            }
+        TemplateCreationAlert("Создать проект")
+        { ViewBody } action: {
+            Task { await addProject(text) }
         }
+    }
+
+    private var ViewBody: some View {
+        TextField(text: $text) {
+            Text("Название проекта")
+                .padding()
+        }
+        .padding()
+        .background(
+            .secondary,
+            in: RoundedRectangle(cornerRadius: 8, style: .continuous).stroke()
+        )
+    }
+
+    private func addProject(_ title: String) async {
+        await viewModel.createProject(title)
+        alertManager.addProjectState.toggle()
     }
 }

--- a/iosApp/iosApp/UI/Screens/ProjectList/ProjectListView.swift
+++ b/iosApp/iosApp/UI/Screens/ProjectList/ProjectListView.swift
@@ -25,7 +25,7 @@ struct ProjectListView: View {
         MainFrameView(viewModel: viewModel, alertManager: alertManager) {
             ForEach(viewModel.projectList.reversed()) { project in
                 NavigationLink(destination: TaskListView(project)) {
-                    ProjectCardView(model: project)
+                    ProjectCardView(model: project, viewModel: viewModel)
                 }
                 .tint(.primary)
             }

--- a/iosApp/iosApp/UI/Screens/ProjectList/ProjectListViewModel.swift
+++ b/iosApp/iosApp/UI/Screens/ProjectList/ProjectListViewModel.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 import shared
 
-@MainActor final class ProjectListViewModel: ObservableObject, Searchable {
+@MainActor final class ProjectListViewModel: ObservableObject, ProjectListViewModelProtocol {
     //    MARK: Props
     private let projectListUseCase = KoinHelper().getProjectListUseCase()
     @Published private(set) var projectList = [ProjectInfo]()
@@ -30,6 +30,16 @@ import shared
     func createProject(_ title: String) async {
         do {
             try await projectListUseCase.createProject(projectName: title)
+            await updateDataSource()
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+
+    func deleteCard(_ id: UInt16) async {
+        do {
+            try await projectListUseCase.deleteProject(projectId: Int32(id))
+            await updateDataSource()
         } catch {
             print(error.localizedDescription)
         }

--- a/iosApp/iosApp/UI/Screens/ProjectList/ProjectListViewModelProtocol.swift
+++ b/iosApp/iosApp/UI/Screens/ProjectList/ProjectListViewModelProtocol.swift
@@ -8,10 +8,4 @@
 
 import Foundation
 
-protocol ProjectListViewModelProtocol: AnyObject {
-    //    MARK: Props
-    var projectListSignal: Box<[TaskInfo]?> { get }
-
-    //    MARK: Methods
-    func updateDataSource()
-}
+protocol ProjectListViewModelProtocol: TaskCardViewModelProtocol, Searchable {}

--- a/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListView.swift
+++ b/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListView.swift
@@ -37,7 +37,7 @@ struct SubTaskListView: View {
 
             SubTaskSectionBG(isEmpty: viewModel.unCompletedSubTaskListSignal.isEmpty) {
                 ForEach(viewModel.unCompletedSubTaskListSignal) { subTask in
-                    SubTaskCardView(model: subTask)
+                    SubTaskCardView(model: subTask, viewModel: viewModel)
                 }
 
                 SubTaskCreationButton()
@@ -45,7 +45,7 @@ struct SubTaskListView: View {
 
             CompletedTaskSectionBG(isEmpty: viewModel.completedSubTaskListSignal.isEmpty) {
                 ForEach(viewModel.completedSubTaskListSignal) { subTask in
-                    SubTaskCardView(model: subTask)
+                    SubTaskCardView(model: subTask, viewModel: viewModel)
                 }
             }
         }

--- a/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListViewModel.swift
+++ b/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListViewModel.swift
@@ -8,7 +8,7 @@
 
 import shared
 
-@MainActor final class SubTaskListViewModel: ObservableObject {
+@MainActor final class SubTaskListViewModel: ObservableObject, SubTaskListViewModelProtocol {
     //    MARK: Props
     private let subTaskListUseCase = KoinHelper().getTaskListUseCase()
     @Published private(set) var unCompletedSubTaskListSignal = [TaskInfo]()
@@ -27,5 +27,13 @@ import shared
         } catch {
             print(error.localizedDescription)
         }
+    }
+
+    func deleteCard(_ id: UInt16) async {
+
+    }
+
+    func search() async {
+        
     }
 }

--- a/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListViewModelProtocol.swift
+++ b/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListViewModelProtocol.swift
@@ -6,10 +6,4 @@
 //  Copyright © 2024 TaskMaster. All rights reserved.
 //
 
-protocol SubTaskListViewModelProtocol: AnyObject {
-    //    MARK: Props
-    var subTaskListSignal: Box<[TaskInfo]?> { get }
-
-    //    MARK: Methods
-    func updateDataSource()
-}
+protocol SubTaskListViewModelProtocol: TaskListViewModelProtocol {}

--- a/iosApp/iosApp/UI/Screens/TaskList/TaskListView.swift
+++ b/iosApp/iosApp/UI/Screens/TaskList/TaskListView.swift
@@ -29,7 +29,7 @@ struct TaskListView: View {
             TaskSectionBG(isEmpty: viewModel.unCompletedTaskListSignal.isEmpty) {
                 ForEach(viewModel.unCompletedTaskListSignal) { task in
                     NavigationLink(destination: SubTaskListView(model.title, model: task)) {
-                        TaskCardView(model: task)
+                        TaskCardView(model: task, viewModel: viewModel)
                     }.tint(.primary)
                 }
 
@@ -42,7 +42,7 @@ struct TaskListView: View {
             CompletedTaskSectionBG(isEmpty: viewModel.completedTaskListSignal.isEmpty) {
                 ForEach(viewModel.completedTaskListSignal) { task in
                     NavigationLink(destination: SubTaskListView(model.title, model: task)) {
-                        TaskCardView(model: task)
+                        TaskCardView(model: task, viewModel: viewModel)
                     }.tint(.primary)
                 }
             }

--- a/iosApp/iosApp/UI/Screens/TaskList/TaskListViewModel.swift
+++ b/iosApp/iosApp/UI/Screens/TaskList/TaskListViewModel.swift
@@ -8,7 +8,7 @@
 
 import shared
 
-@MainActor final class TaskListViewModel: ObservableObject {
+@MainActor final class TaskListViewModel: ObservableObject, TaskListViewModelProtocol {
     //    MARK: Props
     private let taskListUseCase = KoinHelper().getTaskListUseCase()
     @Published private(set) var unCompletedTaskListSignal = [TaskInfo]()
@@ -37,5 +37,13 @@ import shared
     func addCompletedTask() {
 
         //        updateDataSource()
+    }
+
+    func deleteCard(_ id: UInt16) async {
+
+    }
+
+    func search() async {
+
     }
 }

--- a/iosApp/iosApp/UI/Screens/TaskList/TaskListViewModelProtocol.swift
+++ b/iosApp/iosApp/UI/Screens/TaskList/TaskListViewModelProtocol.swift
@@ -8,13 +8,4 @@
 
 import Foundation
 
-protocol TaskListViewModelProtocol: AnyObject {
-    //    MARK: Props
-    var unCompletedTaskListSignal: Box<[TaskInfo]?> { get }
-    var completedTaskListSignal: Box<[TaskInfo]?> { get }
-
-    //    MARK: Methods
-    func updateDataSource()
-    func addUncompletedTask()
-    func addCompletedTask()
-}
+protocol TaskListViewModelProtocol: ProjectListViewModelProtocol {}

--- a/shared/src/commonMain/kotlin/com/example/taskmaster/domain/use_cases/ProjectListUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/example/taskmaster/domain/use_cases/ProjectListUseCase.kt
@@ -12,4 +12,8 @@ class ProjectListUseCase(private val apiService: ApiService) : KoinComponent {
     suspend fun createProject(projectName: String) {
         return apiService.createProject(projectName)
     }
+
+    suspend fun deleteProject(projectId: Int) {
+        return apiService.DeleteTaskOrProject(projectId)
+    }
 }


### PR DESCRIPTION
| shared |

add:
- project deletion method that calls the same method in api service

| ios |

add:
- protocol to card view models with card deletion method
- temlate creation alert

change:
- project card controller with new realization of remove method where it calls it's view model card deletion method
- template card with context menu deletetion action
- project creation alert to call it's view model deletion method