### PR TITLE
finish ios attachment list screen logic

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		CEB458192C18671C0036F73B /* LaborCostTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB458182C18671C0036F73B /* LaborCostTableView.swift */; };
 		CEB4581C2C187AF60036F73B /* TableComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB4581B2C187AF60036F73B /* TableComponents.swift */; };
 		CEB4581F2C187B530036F73B /* EstimationTableViewTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB4581E2C187B530036F73B /* EstimationTableViewTemplate.swift */; };
+		CEB458212C18A3DD0036F73B /* AttachmentListStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB458202C18A3DD0036F73B /* AttachmentListStateManager.swift */; };
+		CEB458232C18B5FD0036F73B /* AttachmentCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB458222C18B5FD0036F73B /* AttachmentCardController.swift */; };
 		CEB4B3002C0DF7C200A6CB96 /* UserListAdditionAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB4B2FF2C0DF7C200A6CB96 /* UserListAdditionAlert.swift */; };
 		CEB57A3E2C1602E6008CE87F /* GanttTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB57A3D2C1602E6008CE87F /* GanttTableView.swift */; };
 		CEB7E56D2BF8AA5A002337B7 /* DetailedTaskInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7E56C2BF8AA5A002337B7 /* DetailedTaskInfo.swift */; };
@@ -237,6 +239,8 @@
 		CEB458182C18671C0036F73B /* LaborCostTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaborCostTableView.swift; sourceTree = "<group>"; };
 		CEB4581B2C187AF60036F73B /* TableComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableComponents.swift; sourceTree = "<group>"; };
 		CEB4581E2C187B530036F73B /* EstimationTableViewTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EstimationTableViewTemplate.swift; sourceTree = "<group>"; };
+		CEB458202C18A3DD0036F73B /* AttachmentListStateManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentListStateManager.swift; sourceTree = "<group>"; };
+		CEB458222C18B5FD0036F73B /* AttachmentCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentCardController.swift; sourceTree = "<group>"; };
 		CEB4B2FF2C0DF7C200A6CB96 /* UserListAdditionAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListAdditionAlert.swift; sourceTree = "<group>"; };
 		CEB57A3D2C1602E6008CE87F /* GanttTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GanttTableView.swift; sourceTree = "<group>"; };
 		CEB7E56C2BF8AA5A002337B7 /* DetailedTaskInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailedTaskInfo.swift; sourceTree = "<group>"; };
@@ -587,6 +591,7 @@
 				28E796092BD96FDA00D402E4 /* AttachmentListModel.swift */,
 				28E795F92BD966B000D402E4 /* AttachmentListView.swift */,
 				28E796072BD96F7E00D402E4 /* AttachmentListViewModel.swift */,
+				CEB458202C18A3DD0036F73B /* AttachmentListStateManager.swift */,
 				28E796052BD96F0C00D402E4 /* AttachmentListViewModelProtocol.swift */,
 				28E7960B2BD973CD00D402E4 /* AttachmentCard */,
 			);
@@ -606,6 +611,7 @@
 			isa = PBXGroup;
 			children = (
 				28E795FC2BD9679800D402E4 /* AttachmentCardView.swift */,
+				CEB458222C18B5FD0036F73B /* AttachmentCardController.swift */,
 				28E7960C2BD973DB00D402E4 /* AttachmentCardAction.swift */,
 			);
 			path = AttachmentCard;
@@ -951,6 +957,7 @@
 				28609D042BD15A42005D2D01 /* ScreenInfoButton.swift in Sources */,
 				2864E6AE2BD38F7600504DE0 /* TaskCardsProtocols.swift in Sources */,
 				28DE0A3B2BCEE7C3001F819C /* TemplateActionButton.swift in Sources */,
+				CEB458212C18A3DD0036F73B /* AttachmentListStateManager.swift in Sources */,
 				CEC6010A2BFDFD280016DC0F /* TemplateCreationAlert.swift in Sources */,
 				CEBB132E2C06253F0017B33D /* UserCreationAlert.swift in Sources */,
 				CED37B352BFCFC0500F9629D /* ProjectListNavBar.swift in Sources */,
@@ -968,6 +975,7 @@
 				28EA9CF52BD5525700B31497 /* ProjectListViewModel.swift in Sources */,
 				CEB4B3002C0DF7C200A6CB96 /* UserListAdditionAlert.swift in Sources */,
 				2864E6B82BD3B4D900504DE0 /* MainFrameAction.swift in Sources */,
+				CEB458232C18B5FD0036F73B /* AttachmentCardController.swift in Sources */,
 				28407DEA2BD1698B004B275D /* TaskCreationButton.swift in Sources */,
 				CEB7E56F2BF8C964002337B7 /* TaskInfoViewModel.swift in Sources */,
 				28E796122BD9A95100D402E4 /* LaborCostListViewModel.swift in Sources */,

--- a/iosApp/iosApp/Helpers/Extensions.swift
+++ b/iosApp/iosApp/Helpers/Extensions.swift
@@ -101,3 +101,16 @@ extension Date {
         return formatter.string(from: self)
     }
 }
+
+extension KotlinByteArray {
+    convenience init(_ data: Data) {
+        let array = data.map { NSNumber(value: $0) }
+
+        self.init(size: .init(data.count))
+
+        for (i, v) in array.enumerated() {
+            self.set(index: .init(i),
+                     value: v.int8Value)
+        }
+    }
+}

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -52,5 +52,9 @@
                 </dict>
             </dict>
         </dict>
+        <key>UIFileSharingEnabled</key>
+        <true/>
+        <key>LSSupportsOpeningDocumentsInPlace</key>
+        <true/>
     </dict>
 </plist>

--- a/iosApp/iosApp/UI/Components/Views/ActionButtons/Views/AttachmentCreationButton/AttachmentCreationButton.swift
+++ b/iosApp/iosApp/UI/Components/Views/ActionButtons/Views/AttachmentCreationButton/AttachmentCreationButton.swift
@@ -15,10 +15,10 @@ struct AttachmentCreationButton: View {
     private let action: Openable
 
     //    MARK: Init
-    init() {
+    init(_ stateManager: AttachmentListStateManager) {
         title = ActionButtonsConstants.Strings.Titles.attachmentTitle
         imageName = ActionButtonsConstants.Strings.ImageNames.attachmentImageName
-        action = AttachmentCreationButtonAction()
+        action = AttachmentCreationButtonAction(stateManager)
     }
 
     //    MARK: Body

--- a/iosApp/iosApp/UI/Components/Views/ActionButtons/Views/AttachmentCreationButton/AttachmentCreationButtonAction.swift
+++ b/iosApp/iosApp/UI/Components/Views/ActionButtons/Views/AttachmentCreationButton/AttachmentCreationButtonAction.swift
@@ -6,6 +6,16 @@
 //  Copyright © 2024 TaskMaster. All rights reserved.
 //
 
+import SwiftUI
+
 struct AttachmentCreationButtonAction: Openable {
-    func open() {}
+    @ObservedObject private var stateManager: AttachmentListStateManager
+
+    init(_ stateManager: AttachmentListStateManager) {
+        self.stateManager = stateManager
+    }
+
+    func open() {
+        stateManager.isFileImporterVisible.toggle()
+    }
 }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardController.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardController.swift
@@ -1,0 +1,38 @@
+//
+//  AttachmentCardController.swift
+//  TaskMaster
+//
+//  Created by  user on 11-06-2024.
+//  Copyright © 2024 TaskMaster. All rights reserved.
+//
+
+import SwiftUI
+import shared
+
+struct AttachmentCardController {
+    @ObservedObject private var viewModel: AttachmentListViewModel
+    private let taskId: UInt16
+    private let attachmentId: KotlinInt
+    private let descriptionId: KotlinInt
+
+    init(viewModel: AttachmentListViewModel,
+         taskId: UInt16,
+         attachmentId: KotlinInt,
+         descriptionId: KotlinInt) {
+        self.viewModel = viewModel
+        self.taskId = taskId
+        self.attachmentId = attachmentId
+        self.descriptionId = descriptionId
+    }
+
+    func download() async {
+        await viewModel.downloadAttachment(taskId: taskId,
+                                           attachmentId: attachmentId)
+    }
+
+    func delete() async {
+        await viewModel.deleteAttachment(taskId: taskId,
+                                         attachmentId: attachmentId,
+                                         descriptionId: descriptionId)
+    }
+}

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardController.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardController.swift
@@ -11,28 +11,24 @@ import shared
 
 struct AttachmentCardController {
     @ObservedObject private var viewModel: AttachmentListViewModel
+    private let attachment: FileDTO
     private let taskId: UInt16
-    private let attachmentId: KotlinInt
-    private let descriptionId: KotlinInt
 
-    init(viewModel: AttachmentListViewModel,
+    init(_ attachment: FileDTO,
          taskId: UInt16,
-         attachmentId: KotlinInt,
-         descriptionId: KotlinInt) {
+         viewModel: AttachmentListViewModel) {
         self.viewModel = viewModel
         self.taskId = taskId
-        self.attachmentId = attachmentId
-        self.descriptionId = descriptionId
+        self.attachment = attachment
     }
 
     func download() async {
-        await viewModel.downloadAttachment(taskId: taskId,
-                                           attachmentId: attachmentId)
+        await viewModel.downloadAttachment(attachment,
+                                           taskId: taskId)
     }
 
     func delete() async {
-        await viewModel.deleteAttachment(taskId: taskId,
-                                         attachmentId: attachmentId,
-                                         descriptionId: descriptionId)
+        await viewModel.deleteAttachment(attachment,
+                                         taskId: taskId)
     }
 }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardView.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardView.swift
@@ -11,23 +11,19 @@ import shared
 
 struct AttachmentCardView: View {
     //    MARK: Props
-    private let attachment: FileDTO
+    private let controller: AttachmentCardController
     private let title: String
     private let imageName: String
-    private let controller: AttachmentCardController
 
     //    MARK: Init
     init(_ attachment: FileDTO,
          taskId: UInt16,
          viewModel: AttachmentListViewModel)
     {
-        self.attachment = attachment
+        controller = AttachmentCardController(attachment, taskId: taskId, viewModel: viewModel)
+        
         title = "\(attachment.orig_filename ?? .init()).\(attachment.type ?? .init())"
         imageName = Constants.Strings.ImageNames.extraActionsImageName
-        controller = AttachmentCardController(viewModel: viewModel,
-                                              taskId: taskId,
-                                              attachmentId: attachment.id ?? 0,
-                                              descriptionId: attachment.descriptionId ?? 0)
     }
 
     //    MARK: Body

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardView.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardView.swift
@@ -7,18 +7,27 @@
 //
 
 import SwiftUI
+import shared
 
 struct AttachmentCardView: View {
     //    MARK: Props
+    private let attachment: FileDTO
     private let title: String
     private let imageName: String
-    private let action: Openable
+    private let controller: AttachmentCardController
 
     //    MARK: Init
-    init(_ title: String) {
-        self.title = title
+    init(_ attachment: FileDTO,
+         taskId: UInt16,
+         viewModel: AttachmentListViewModel)
+    {
+        self.attachment = attachment
+        title = "\(attachment.orig_filename ?? .init()).\(attachment.type ?? .init())"
         imageName = Constants.Strings.ImageNames.extraActionsImageName
-        action = AttachmentCreationButtonAction()
+        controller = AttachmentCardController(viewModel: viewModel,
+                                              taskId: taskId,
+                                              attachmentId: attachment.id ?? 0,
+                                              descriptionId: attachment.descriptionId ?? 0)
     }
 
     //    MARK: Body
@@ -28,7 +37,23 @@ struct AttachmentCardView: View {
 
             Spacer()
 
-            Button(action: { action.open() }) {
+            Menu {
+                Button {
+                    Task {
+                        await controller.download()
+                    }
+                } label: {
+                    Label("Скачать", systemImage: "square.and.arrow.down")
+                }
+
+                Button(role: .destructive) {
+                    Task {
+                        await controller.delete()
+                    }
+                } label: {
+                    Label("Удалить", systemImage: "delete.left")
+                }
+            } label: {
                 Image(systemName: imageName)
             }
         }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListStateManager.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListStateManager.swift
@@ -10,4 +10,5 @@ import SwiftUI
 
 class AttachmentListStateManager: ObservableObject, UserListVisible {
     @Published var isUserListVisible = false
+    @Published var isFileImporterVisible = false
 }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListStateManager.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListStateManager.swift
@@ -1,0 +1,13 @@
+//
+//  AttachmentListStateManager.swift
+//  TaskMaster
+//
+//  Created by  user on 11-06-2024.
+//  Copyright © 2024 TaskMaster. All rights reserved.
+//
+
+import SwiftUI
+
+class AttachmentListStateManager: ObservableObject, UserListVisible {
+    @Published var isUserListVisible = false
+}

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListView.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListView.swift
@@ -30,6 +30,18 @@ struct AttachmentListView: View {
             .task {
                 await viewModel.updateDataSource(taskId)
             }
+            .fileImporter(
+                isPresented: $stateManager.isFileImporterVisible,
+                allowedContentTypes: [.pdf]
+            ) { result in
+                switch result {
+                case .success(let url):
+                    Task { await viewModel.addAttachment(url, taskId) }
+
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
     }
 
     private var viewBody: some View {
@@ -47,6 +59,6 @@ struct AttachmentListView: View {
                                viewModel: viewModel)
         }.padding(.horizontal, 40)
 
-        AttachmentCreationButton()
+        AttachmentCreationButton(stateManager)
     }
 }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListView.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListView.swift
@@ -32,7 +32,7 @@ struct AttachmentListView: View {
             }
             .fileImporter(
                 isPresented: $stateManager.isFileImporterVisible,
-                allowedContentTypes: [.pdf]
+                allowedContentTypes: [.item]
             ) { result in
                 switch result {
                 case .success(let url):

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListViewModel.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListViewModel.swift
@@ -63,8 +63,11 @@ final class AttachmentListViewModel: ObservableObject, Searchable {
 
             try imageData.write(to: imageName)
 
-            print("imgTempURL: " + tempFileUrl.absoluteString)
-            print("imgURL: " + imageName.absoluteString)
+            if FileManager.default.fileExists(atPath: imageName.path) {
+                print("Image successfully saved at \(imageName.path)")
+            } else {
+                print("Failed to save image")
+            }
         } catch {
             print(error.localizedDescription)
         }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListViewModel.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListViewModel.swift
@@ -80,5 +80,22 @@ final class AttachmentListViewModel: ObservableObject, Searchable {
         }
     }
 
+    func addAttachment(
+        _ url: URL,
+        _ taskId: UInt16
+    ) async {
+        do {
+            let title = url.lastPathComponent
+            let data = try Data(contentsOf: url)
+
+            try await attachmentListUseCase.addAttachment(taskId: .init(taskId),
+                                                          title: title,
+                                                          data: .init(data))
+            await updateDataSource(taskId)
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+
     func search() async {}
 }

--- a/iosApp/iosApp/UI/Screens/EstimationTable/TableViews/GanttTableView.swift
+++ b/iosApp/iosApp/UI/Screens/EstimationTable/TableViews/GanttTableView.swift
@@ -28,7 +28,7 @@ struct GanttTableView: View {
             .sorted { $0.0 < $1.0 }
 
         let hoursGanttData = ganttList.flatMap { task in
-            task.execution_date.map { dateString in
+            task.execution_date.map { dateString -> (Date, String, Int32) in
                 let date = dateString as? String ?? .init()
                 return (date.toGanttDate(), String(task.haveExecuter), task.taskId)
             }

--- a/iosApp/iosApp/UI/Screens/EstimationTable/TableViews/LaborCostTableView.swift
+++ b/iosApp/iosApp/UI/Screens/EstimationTable/TableViews/LaborCostTableView.swift
@@ -20,7 +20,7 @@ struct LaborCostTableView: View {
         let uniqueDateList = Array(Set(dateList)).sorted()
 
         let uniqueTaskIdList = Array(Set(laborCostList.compactMap { $0.taskId }))
-        let laborList = uniqueTaskIdList.map { taskId  in
+        let laborList = uniqueTaskIdList.map { taskId  -> (Int32, String) in
             let hoursSpent = laborCostList.first { $0.taskId == taskId }?.hoursSpent ?? "-"
             return (taskId, hoursSpent)
         }.sorted { $0.0 < $1.0 }

--- a/iosApp/iosApp/UI/Screens/LoginScreen/LoginItems/LoginScreenViewModel.swift
+++ b/iosApp/iosApp/UI/Screens/LoginScreen/LoginItems/LoginScreenViewModel.swift
@@ -6,11 +6,13 @@
 //  Copyright © 2024 TaskMaster. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
 import shared
 
-@MainActor final class LoginScreenViewModel: ObservableObject {
+@MainActor
+final class LoginScreenViewModel: ObservableObject {
     //    MARK: Props
+    @AppStorage("userToken") private var userToken: String?
     private let accessTokenDtoUseCase = KoinHelper().getAccessTokenDtoUseCase()
 
     //    MARK: Methods
@@ -21,6 +23,8 @@ import shared
                                                                               password: password),
                 let token = tokenDto.tokenLong
             else { return false }
+
+            userToken = token
 
             return token.isEmpty ? false : true
         } catch {

--- a/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListView.swift
+++ b/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListView.swift
@@ -53,8 +53,7 @@ struct SubTaskListView: View {
             DescriptionBody
 
             NavigationLink(destination: AttachmentListView(title,
-                                                           taskId: model.id,
-                                                           stateManager: stateManager)) {
+                                                           taskId: model.id)) {
                 AttachmentsScreenInfoButton()
             }.tint(.primary)
 

--- a/shared/src/commonMain/kotlin/com/example/taskmaster/domain/use_cases/AttachmentListUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/example/taskmaster/domain/use_cases/AttachmentListUseCase.kt
@@ -12,4 +12,8 @@ class AttachmentListUseCase(private val apiService: ApiService) : KoinComponent 
     suspend fun deleteAttachment(attachmentId: Int, descriptionId: Int) {
         return apiService.deleteFile(descriptionId, attachmentId)
     }
+
+    suspend fun addAttachment(taskId: Int, title: String, data: ByteArray) {
+        return apiService.sendFile(title, taskId, data)
+    }
 }

--- a/shared/src/commonMain/kotlin/com/example/taskmaster/domain/use_cases/AttachmentListUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/example/taskmaster/domain/use_cases/AttachmentListUseCase.kt
@@ -1,0 +1,15 @@
+package com.example.taskmaster.domain.use_cases
+
+import com.example.taskmaster.data.network.ApiService
+import com.example.taskmaster.data.network.models.FileDTO
+import org.koin.core.component.KoinComponent
+
+class AttachmentListUseCase(private val apiService: ApiService) : KoinComponent {
+    suspend fun getAttachmentList(taskId: Int): List<FileDTO>? {
+        return apiService.listFileInTask(taskId)?.file_resources
+    }
+
+    suspend fun deleteAttachment(attachmentId: Int, descriptionId: Int) {
+        return apiService.deleteFile(descriptionId, attachmentId)
+    }
+}

--- a/shared/src/iosMain/kotlin/com/example/taskmaster/di/CommonModule.ios.kt
+++ b/shared/src/iosMain/kotlin/com/example/taskmaster/di/CommonModule.ios.kt
@@ -1,6 +1,7 @@
 package com.example.taskmaster.di
 
 import com.example.taskmaster.domain.use_cases.AccessTokenUseCase
+import com.example.taskmaster.domain.use_cases.AttachmentListUseCase
 import com.example.taskmaster.domain.use_cases.EstimationTableUseCase
 import com.example.taskmaster.domain.use_cases.LaborCostListUseCase
 import com.example.taskmaster.domain.use_cases.ProjectListUseCase
@@ -20,6 +21,7 @@ actual fun platformModule() = module {
     single { TaskInfoUseCase(get()) }
     single { LaborCostListUseCase(get()) }
     single { EstimationTableUseCase(get()) }
+    single { AttachmentListUseCase(get()) }
 }
 
 object KoinHelper : KoinComponent {
@@ -29,4 +31,5 @@ object KoinHelper : KoinComponent {
     fun getTaskInfoUseCase() = get<TaskInfoUseCase>()
     fun getLaborCostListUseCase() = get<LaborCostListUseCase>()
     fun getEstimationTableUseCase() = get<EstimationTableUseCase>()
+    fun getAttachmentListUseCase() = get<AttachmentListUseCase>()
 }


### PR DESCRIPTION
- add attachment card controller with attachment downloading and deletion logic
- add menu button to attachment card with downloading and deletion logic
- add attachment state manager to store modal sheets visibility states
- add files attachment, downloading and deletion logic to attachments list view model
- add user defaults value that stores an auth token
- add Kotlin byte array extension to give it an ability of being initialized with value of swift data type
- add file picker sheet presentation in file attachment button action
- add file picker sheet presentation on it's state value changes in attachments list view
- add files attachment, downloading and deletion logic to attachment list use case