### PR TITLE
finish ios destructive alert templates

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		CEB458232C18B5FD0036F73B /* AttachmentCardController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB458222C18B5FD0036F73B /* AttachmentCardController.swift */; };
 		CEB4B3002C0DF7C200A6CB96 /* UserListAdditionAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB4B2FF2C0DF7C200A6CB96 /* UserListAdditionAlert.swift */; };
 		CEB57A3E2C1602E6008CE87F /* GanttTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB57A3D2C1602E6008CE87F /* GanttTableView.swift */; };
+		CEB73B4B2C1C6BDD00F921F1 /* DestructiveAlertTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB73B4A2C1C6BDD00F921F1 /* DestructiveAlertTemplate.swift */; };
 		CEB7E56D2BF8AA5A002337B7 /* DetailedTaskInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7E56C2BF8AA5A002337B7 /* DetailedTaskInfo.swift */; };
 		CEB7E56F2BF8C964002337B7 /* TaskInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB7E56E2BF8C964002337B7 /* TaskInfoViewModel.swift */; };
 		CEBB132A2C05E9EC0017B33D /* LaborCostInfoAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBB13292C05E9EC0017B33D /* LaborCostInfoAlert.swift */; };
@@ -243,6 +244,7 @@
 		CEB458222C18B5FD0036F73B /* AttachmentCardController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentCardController.swift; sourceTree = "<group>"; };
 		CEB4B2FF2C0DF7C200A6CB96 /* UserListAdditionAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListAdditionAlert.swift; sourceTree = "<group>"; };
 		CEB57A3D2C1602E6008CE87F /* GanttTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GanttTableView.swift; sourceTree = "<group>"; };
+		CEB73B4A2C1C6BDD00F921F1 /* DestructiveAlertTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestructiveAlertTemplate.swift; sourceTree = "<group>"; };
 		CEB7E56C2BF8AA5A002337B7 /* DetailedTaskInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailedTaskInfo.swift; sourceTree = "<group>"; };
 		CEB7E56E2BF8C964002337B7 /* TaskInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskInfoViewModel.swift; sourceTree = "<group>"; };
 		CEBB13292C05E9EC0017B33D /* LaborCostInfoAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaborCostInfoAlert.swift; sourceTree = "<group>"; };
@@ -301,9 +303,9 @@
 			isa = PBXGroup;
 			children = (
 				287638FB2BB1ED3700B55DBF /* TemplateTaskCardView.swift */,
+				288455EA2BD2DF8200DF64E5 /* ProjectCard */,
 				288455E82BD2DF6D00DF64E5 /* TaskCard */,
 				288455E92BD2DF7400DF64E5 /* SubTaskCard */,
-				288455EA2BD2DF8200DF64E5 /* ProjectCard */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -569,6 +571,7 @@
 			children = (
 				CED884AE2C07252A00617B3D /* UserListAlerts */,
 				CEC601082BFDFD000016DC0F /* CreationAlerts */,
+				CEB73B4C2C1C6C8C00F921F1 /* DestructiveAlerts */,
 			);
 			path = ModalScreens;
 			sourceTree = "<group>";
@@ -765,6 +768,14 @@
 				CEB4581A2C187AD50036F73B /* Components */,
 			);
 			path = EstimationTable;
+			sourceTree = "<group>";
+		};
+		CEB73B4C2C1C6C8C00F921F1 /* DestructiveAlerts */ = {
+			isa = PBXGroup;
+			children = (
+				CEB73B4A2C1C6BDD00F921F1 /* DestructiveAlertTemplate.swift */,
+			);
+			path = DestructiveAlerts;
 			sourceTree = "<group>";
 		};
 		CEC085FA2BF79B2600BBBEC2 /* Helpers */ = {
@@ -1035,6 +1046,7 @@
 				28E796082BD96F7E00D402E4 /* AttachmentListViewModel.swift in Sources */,
 				287638FC2BB1ED3700B55DBF /* TemplateTaskCardView.swift in Sources */,
 				CEB30E162C0F6A88000B1139 /* StateManagerProtocols.swift in Sources */,
+				CEB73B4B2C1C6BDD00F921F1 /* DestructiveAlertTemplate.swift in Sources */,
 				CEE483982BFF53E6005A9596 /* SubTaskListStateManager.swift in Sources */,
 				28EA9CF92BD5539300B31497 /* ProjectListModel.swift in Sources */,
 				288455EC2BD2DFD300DF64E5 /* TaskCardController.swift in Sources */,

--- a/iosApp/iosApp/Helpers/Constants.swift
+++ b/iosApp/iosApp/Helpers/Constants.swift
@@ -14,5 +14,11 @@ enum Constants {
             static let extraActionsImageName = "ellipsis"
             static let searchActionImageName = "rectangle.and.text.magnifyingglass"
         }
+
+        enum DestructiveAlertMessage {
+            static let warningTitle = "Вы уверены?"
+            static let confirmationActionTitle = "Да"
+            static let denialActionTitle = "Нет"
+        }
     }
 }

--- a/iosApp/iosApp/Helpers/Protocols/StateManagerProtocols.swift
+++ b/iosApp/iosApp/Helpers/Protocols/StateManagerProtocols.swift
@@ -16,4 +16,18 @@ protocol UserAdditionAlertVisible: ObservableObject {
     var isUserAdditionAlertVisible: Bool { get set }
 }
 
-protocol TaskListStateManagerProtocol: UserListVisible, UserAdditionAlertVisible {}
+protocol TaskListStateManagerProtocol: UserListVisible, UserAdditionAlertVisible, CardDeletionAlertPresentable {}
+
+protocol CardDeletionAlertPresentable: ObservableObject {
+    var isCardDeletionAlertPresented: Bool { get set }
+    var isCardDeletionAlertPresentedBinding: Binding<Bool> { get }
+}
+
+extension CardDeletionAlertPresentable {
+    var isCardDeletionAlertPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { self.isCardDeletionAlertPresented },
+            set: { self.isCardDeletionAlertPresented = $0 }
+        )
+    }
+}

--- a/iosApp/iosApp/UI/Components/Views/NavBars/ProjectListNavBar.swift
+++ b/iosApp/iosApp/UI/Components/Views/NavBars/ProjectListNavBar.swift
@@ -9,8 +9,6 @@
 import SwiftUI
 
 struct ProjectListNavBar<Content: View>: View {
-    @EnvironmentObject var authViewModel: AuthViewModel
-
     @ViewBuilder private let content: () -> Content
     @ObservedObject private var stateManager: ProjectListStateManager
 
@@ -48,7 +46,9 @@ struct ProjectListNavBar<Content: View>: View {
             Label("Добавить проект", systemImage: "plus.rectangle.on.rectangle")
         }
 
-        Button(role: .destructive, action: { authViewModel.isAuthenticated = false }) {
+        Button(role: .destructive) {
+            stateManager.isLogOutAlertPresented = true
+        } label: {
             Label("Выйти", systemImage: "rectangle.portrait.and.arrow.right")
                 .tint(Color(uiColor: .systemPink))
         }

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/TaskCardsProtocols.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/TaskCardsProtocols.swift
@@ -6,13 +6,15 @@
 //  Copyright © 2024 TaskMaster. All rights reserved.
 //
 
+import SwiftUI
+
 // MARK: - General
 protocol TaskCardActions: Openable & Removable {}
 
 protocol CardInfoProtocol {
     var model: any TaskInfoProtocol { get }
 
-//    init(_ projectId: UInt16, model: any TaskInfoProtocol, viewModel: TaskCardViewModelProtocol)
+    //    init(_ projectId: UInt16, model: any TaskInfoProtocol, viewModel: TaskCardViewModelProtocol)
 }
 
 protocol TaskTitleProvider: CardInfoProtocol {
@@ -43,4 +45,43 @@ protocol TaskNumberTitleProvider: CardInfoProtocol {
 
 protocol CategoriesTitleProvider: CardInfoProtocol {
     var categoriesTitle: String { get }
+}
+
+protocol CardDeletionAlertTitleProvider {
+    var cardDeletionAlertTitle: String { get }
+}
+
+protocol TaskCardDeletionAlertTitleProvider: CardDeletionAlertTitleProvider {}
+
+extension TaskCardDeletionAlertTitleProvider {
+    var cardDeletionAlertTitle: String { "задачи"}
+}
+
+protocol CardDeletionAlertBindingProvider {
+    var stateManager: any CardDeletionAlertPresentable { get }
+    var isCardDeletionAlertPresentedBinding: Binding<Bool> { get }
+}
+
+extension CardDeletionAlertBindingProvider {
+    var isCardDeletionAlertPresentedBinding: Binding<Bool> {
+        Binding(
+            get: { self.stateManager.isCardDeletionAlertPresented },
+            set: { self.stateManager.isCardDeletionAlertPresented = $0 }
+        )
+    }
+}
+
+protocol DestructiveAlertPresentable: CardDeletionAlertBindingProvider {
+    func showDeletionAlert()
+    func hideDeletionAlert()
+}
+
+extension DestructiveAlertPresentable {
+    func showDeletionAlert() {
+        stateManager.isCardDeletionAlertPresentedBinding.wrappedValue = true
+    }
+
+    func hideDeletionAlert() {
+        stateManager.isCardDeletionAlertPresentedBinding.wrappedValue = false
+    }
 }

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardController.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardController.swift
@@ -8,23 +8,31 @@
 
 import SwiftUI
 
-final class ProjectCardController: ProjectCardControllerProtocol {
+final class ProjectCardController: ProjectCardControllerProtocol, CardDeletionAlertTitleProvider {
     //    MARK: Props
     private var viewModel: any ProjectCardViewModelProtocol
+    var stateManager: any CardDeletionAlertPresentable
     let model: any TaskInfoProtocol
 
+    var cardDeletionAlertTitle = "проекта"
+
     //    MARK: Init
-    init(_ projectId: UInt16, model: any TaskInfoProtocol, viewModel: any ProjectCardViewModelProtocol) {
+    init(_ projectId: UInt16,
+         _ model: any TaskInfoProtocol,
+         _ stateManager: any CardDeletionAlertPresentable,
+         _ viewModel: any ProjectCardViewModelProtocol)
+    {
         self.model = model
+        self.stateManager = stateManager
         self.viewModel = viewModel
     }
 
     //    MARK: Methods
-    func open() {}
-
     func remove() async {
         Task {
             await viewModel.deleteCard(model.id)
         }
     }
+
+    func open() {}
 }

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardControllerProtocol.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/ProjectCard/ProjectCardControllerProtocol.swift
@@ -9,4 +9,7 @@
 protocol ProjectCardControllerProtocol: TaskCardActions,
                                         TaskTitleProvider,
                                         TimerTitleProvider,
-                                        ParticipiantsTitleProvider {}
+                                        ParticipiantsTitleProvider,
+                                        CardDeletionAlertTitleProvider,
+                                        CardDeletionAlertBindingProvider,
+                                        DestructiveAlertPresentable {}

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardController.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardController.swift
@@ -8,23 +8,29 @@
 
 final class SubTaskCardController: SubTaskCardControllerProtocol {
     //    MARK: Props
-    private let parentId: UInt16
     private let viewModel: any TaskCardViewModelProtocol
+    var stateManager: any CardDeletionAlertPresentable
     let model: any TaskInfoProtocol
+
+    private let parentId: UInt16
     var isCompleted: Bool {
         model.statusId == 1
     }
+    var cardDeletionAlertTitle = "задачи"
 
     //    MARK: Init
-    init(_ projectId: UInt16, model: any TaskInfoProtocol, viewModel: any TaskCardViewModelProtocol) {
-        self.parentId = projectId
+    init(_ projectId: UInt16,
+         _ model: any TaskInfoProtocol,
+         _ stateManager: any CardDeletionAlertPresentable,
+         _ viewModel: any TaskCardViewModelProtocol)
+    {
+        parentId = projectId
         self.model = model
+        self.stateManager = stateManager
         self.viewModel = viewModel
     }
 
     //    MARK: Methods
-    func open() {}
-
     func remove() async {
         Task {
             await viewModel.deleteCard(model.id)
@@ -45,4 +51,6 @@ final class SubTaskCardController: SubTaskCardControllerProtocol {
             await viewModel.updateDataSource(parentId)
         }
     }
+
+    func open() {}
 }

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardView.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/SubTaskCard/SubTaskCardView.swift
@@ -13,8 +13,15 @@ struct SubTaskCardView: View {
     private let controller: SubTaskCardControllerProtocol
 
     //    MARK: Init
-    init(_ parentId: UInt16, model: TaskInfo, viewModel: any TaskCardViewModelProtocol) {
-        controller = SubTaskCardController(parentId, model: model, viewModel: viewModel)
+    init(_ parentId: UInt16,
+         _ model: TaskInfo,
+         _ stateManager: any CardDeletionAlertPresentable,
+         _ viewModel: any TaskCardViewModelProtocol)
+    {
+        controller = SubTaskCardController(parentId,
+                                           model,
+                                           stateManager,
+                                           viewModel)
     }
 
     //    MARK: Body

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardController.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardController.swift
@@ -10,23 +10,29 @@ import shared
 
 final class TaskCardController: TaskCardControllerProtocol {
     //    MARK: Props
-    private let parentId: UInt16
-    let model: any TaskInfoProtocol
     private let viewModel: any TaskCardViewModelProtocol
+    var stateManager: any CardDeletionAlertPresentable
+    let model: any TaskInfoProtocol
+    
+    private let parentId: UInt16
     var isCompleted: Bool {
         model.statusId == 1
     }
+    var cardDeletionAlertTitle = "задачи"
 
     //    MARK: Init
-    init(_ projectId: UInt16, model: any TaskInfoProtocol, viewModel: any TaskCardViewModelProtocol) {
+    init(_ projectId: UInt16,
+         _ model: any TaskInfoProtocol,
+         _ stateManager: any CardDeletionAlertPresentable,
+         _ viewModel: any TaskCardViewModelProtocol)
+    {
         parentId = projectId
         self.model = model
+        self.stateManager = stateManager
         self.viewModel = viewModel
     }
 
     //    MARK: Methods
-    func open() {}
-
     func remove() async {
         Task {
             await viewModel.deleteCard(model.id)
@@ -47,4 +53,6 @@ final class TaskCardController: TaskCardControllerProtocol {
             await viewModel.updateDataSource(parentId)
         }
     }
+
+    func open() {}
 }

--- a/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardView.swift
+++ b/iosApp/iosApp/UI/Components/Views/TaskCards/Views/TaskCard/TaskCardView.swift
@@ -10,19 +10,25 @@ import SwiftUI
 
 struct TaskCardView: View {
     //    MARK: Props
-    private let controller: TaskCardControllerProtocol
+    private let controller: any TaskCardControllerProtocol
 
     //    MARK: Init
     /// Initializes the view with specified controller.
     /// - Parameters:
     ///   - controller: An object conforming to the TaskCardControllerProtocol that will serve as the controller for this view.
-    init(controller: TaskCardControllerProtocol) {
+    init(controller: any TaskCardControllerProtocol) {
         self.controller = controller
     }
 
     /// Initializes the view with default realization.
-    init(_ parentId: UInt16, model: any TaskInfoProtocol, viewModel: any TaskCardViewModelProtocol) {
-        controller = TaskCardController(parentId, model: model, viewModel: viewModel)
+    init(_ parentId: UInt16, 
+         _ model: any TaskInfoProtocol,
+         _ stateManager: any CardDeletionAlertPresentable,
+         _ viewModel: any TaskCardViewModelProtocol) {
+        controller = TaskCardController(parentId,
+                                        model,
+                                        stateManager,
+                                        viewModel)
     }
 
     //    MARK: Body

--- a/iosApp/iosApp/UI/ModalScreens/DestructiveAlerts/DestructiveAlertTemplate.swift
+++ b/iosApp/iosApp/UI/ModalScreens/DestructiveAlerts/DestructiveAlertTemplate.swift
@@ -1,0 +1,44 @@
+//
+//  DestructiveAlertTemplate.swift
+//  TaskMaster
+//
+//  Created by  user on 14-06-2024.
+//  Copyright © 2024 TaskMaster. All rights reserved.
+//
+
+import SwiftUI
+
+struct DestructiveAlertTemplate {
+    //    @Binding var isPresented: Bool
+
+    private let title: String
+    private let message: String
+
+    private let primaryButtonTitle: String
+    private let secondaryButtonTitle: String
+
+    private let primaryButtonAction: () -> Void
+    private let secondaryButtonAction: () -> Void
+
+    init(_ title: String,
+         //         _ isPresented: Binding<Bool>,
+         primaryButtonAction: @escaping () -> Void,
+         secondaryButtonAction: @escaping () -> Void)
+    {
+        self.title = title
+        self.primaryButtonAction = primaryButtonAction
+        self.secondaryButtonAction = secondaryButtonAction
+        //        self._isPresented = isPresented
+
+        message = Constants.Strings.DestructiveAlertMessage.warningTitle
+        primaryButtonTitle = Constants.Strings.DestructiveAlertMessage.confirmationActionTitle
+        secondaryButtonTitle = Constants.Strings.DestructiveAlertMessage.denialActionTitle
+    }
+
+    var body: Alert {
+        .init(title: Text(title),
+              message: Text(message),
+              primaryButton: .destructive(Text(primaryButtonTitle)) { primaryButtonAction() },
+              secondaryButton: .cancel(Text(secondaryButtonTitle)) { /*isPresented = false*/ secondaryButtonAction() })
+    }
+}

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardController.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentCard/AttachmentCardController.swift
@@ -11,15 +11,27 @@ import shared
 
 struct AttachmentCardController {
     @ObservedObject private var viewModel: AttachmentListViewModel
+    @ObservedObject private var stateManager: AttachmentListStateManager
     private let attachment: FileDTO
     private let taskId: UInt16
 
+    let deletionAlertTitle = "Удаленить вложение"
+    @Binding var isDeletionAlertPresented: Bool
+
     init(_ attachment: FileDTO,
-         taskId: UInt16,
-         viewModel: AttachmentListViewModel) {
-        self.viewModel = viewModel
-        self.taskId = taskId
+         _ taskId: UInt16,
+         _ stateManager: AttachmentListStateManager,
+         _ viewModel: AttachmentListViewModel) {
         self.attachment = attachment
+        self.taskId = taskId
+        self.stateManager = stateManager
+        self.viewModel = viewModel
+
+        _isDeletionAlertPresented = .init(get: {
+            stateManager.isDeletionAlertPresented
+        }, set: { value in
+            stateManager.isDeletionAlertPresented = value
+        })
     }
 
     func download() async {
@@ -30,5 +42,13 @@ struct AttachmentCardController {
     func delete() async {
         await viewModel.deleteAttachment(attachment,
                                          taskId: taskId)
+    }
+
+    func showDeletionAlert() {
+        stateManager.isDeletionAlertPresented = true
+    }
+
+    func hideDeletionAlert() {
+        stateManager.isDeletionAlertPresented = false
     }
 }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListStateManager.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListStateManager.swift
@@ -11,4 +11,5 @@ import SwiftUI
 class AttachmentListStateManager: ObservableObject, UserListVisible {
     @Published var isUserListVisible = false
     @Published var isFileImporterVisible = false
+    @Published var isDeletionAlertPresented = false
 }

--- a/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListView.swift
+++ b/iosApp/iosApp/UI/Screens/AttachmentList/AttachmentListView.swift
@@ -70,8 +70,9 @@ struct AttachmentListView: View {
     private var attachmentList: some View {
         ForEach(filteredItems, id: \.id) { attachment in
             AttachmentCardView(attachment,
-                               taskId: taskId,
-                               viewModel: viewModel)
+                               taskId,
+                               stateManager,
+                               viewModel)
         }.padding(.horizontal, 40)
 
         AttachmentCreationButton(stateManager)

--- a/iosApp/iosApp/UI/Screens/ProjectList/ProjectListStateManager.swift
+++ b/iosApp/iosApp/UI/Screens/ProjectList/ProjectListStateManager.swift
@@ -8,8 +8,11 @@
 
 import SwiftUI
 
-final class ProjectListStateManager: ObservableObject {
+final class ProjectListStateManager: CardDeletionAlertPresentable {
     @Published var addProjectState = false
     @Published var addUserState = false
     @Published var deleteUserState = false
+
+    @Published var isLogOutAlertPresented = false
+    @Published var isCardDeletionAlertPresented = false
 }

--- a/iosApp/iosApp/UI/Screens/ProjectList/ProjectListView.swift
+++ b/iosApp/iosApp/UI/Screens/ProjectList/ProjectListView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct ProjectListView: View {
     //    MARK: Props
+    @EnvironmentObject var authViewModel: AuthViewModel
+
     @StateObject private var viewModel = ProjectListViewModel()
     @StateObject private var stateManager = ProjectListStateManager()
 
@@ -41,7 +43,7 @@ struct ProjectListView: View {
         MainFrameView(viewModel: viewModel, alertManager: stateManager) {
             ForEach(filteredItems) { project in
                 NavigationLink(destination: TaskListView(project)) {
-                    ProjectCardView(model: project, viewModel: viewModel) { EmptyView() }
+                    ProjectCardView(project, stateManager, viewModel) { EmptyView() }
                 }
                 .tint(.primary)
             }
@@ -55,5 +57,13 @@ struct ProjectListView: View {
         .sheet(isPresented: $stateManager.deleteUserState, content: {
             UserListDeletionAlert(stateManager, viewModel: viewModel)
         })
+        .alert(isPresented: $stateManager.isLogOutAlertPresented) {
+            DestructiveAlertTemplate("Выход из аккаунта") {
+                authViewModel.isAuthenticated = false
+            } secondaryButtonAction: {
+                stateManager.isLogOutAlertPresented = false
+            }.body
+            /*$stateManager.isLogOutAlertPresented)*/
+        }
     }
 }

--- a/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListStateManager.swift
+++ b/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListStateManager.swift
@@ -12,4 +12,5 @@ final class SubTaskListStateManager: TaskListStateManagerProtocol {
     @Published var isCreationAlertShown = false
     @Published var isUserListVisible = false
     @Published var isUserAdditionAlertVisible = false
+    @Published var isCardDeletionAlertPresented = false
 }

--- a/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListView.swift
+++ b/iosApp/iosApp/UI/Screens/SubTaskList/SubTaskListView.swift
@@ -92,7 +92,10 @@ struct SubTaskListView: View {
 
             SubTaskSectionBG(isEmpty: viewModel.unCompletedSubTaskListSignal.isEmpty) {
                 ForEach(filteredItems.unCompletedTaskList) { subTask in
-                    SubTaskCardView(model.id, model: subTask, viewModel: viewModel)
+                    SubTaskCardView(model.id,
+                                    subTask,
+                                    stateManager,
+                                    viewModel)
                 }
 
                 SubTaskCreationButton(stateManager: stateManager)
@@ -100,7 +103,10 @@ struct SubTaskListView: View {
 
             CompletedTaskSectionBG(isEmpty: viewModel.completedSubTaskListSignal.isEmpty) {
                 ForEach(filteredItems.completedTaskList) { subTask in
-                    SubTaskCardView(model.id, model: subTask, viewModel: viewModel)
+                    SubTaskCardView(model.id,
+                                    subTask,
+                                    stateManager,
+                                    viewModel)
                 }
             }
         }

--- a/iosApp/iosApp/UI/Screens/TaskList/TaskListStateManager.swift
+++ b/iosApp/iosApp/UI/Screens/TaskList/TaskListStateManager.swift
@@ -12,4 +12,5 @@ final class TaskListStateManager: TaskListStateManagerProtocol {
     @Published var addTaskState = false
     @Published var isUserListVisible = false
     @Published var isUserAdditionAlertVisible = false
+    @Published var isCardDeletionAlertPresented = false
 }

--- a/iosApp/iosApp/UI/Screens/TaskList/TaskListView.swift
+++ b/iosApp/iosApp/UI/Screens/TaskList/TaskListView.swift
@@ -80,7 +80,10 @@ struct TaskListView: View {
             TaskSectionBG(isEmpty: viewModel.unCompletedTaskListSignal.isEmpty) {
                 ForEach(filteredItems.unCompletedTaskList) { task in
                     NavigationLink(destination: SubTaskListView(model.title, projectId: model.id, model: task)) {
-                        TaskCardView(model.id, model: task, viewModel: viewModel)
+                        TaskCardView(model.id,
+                                     task,
+                                     stateManager,
+                                     viewModel)
                     }.tint(.primary)
                 }
 
@@ -90,7 +93,10 @@ struct TaskListView: View {
             CompletedTaskSectionBG(isEmpty: viewModel.completedTaskListSignal.isEmpty) {
                 ForEach(filteredItems.completedTaskList) { task in
                     NavigationLink(destination: SubTaskListView(model.title, projectId: model.id, model: task)) {
-                        TaskCardView(model.id, model: task, viewModel: viewModel)
+                        TaskCardView(model.id,
+                                     task,
+                                     stateManager,
+                                     viewModel)
                     }.tint(.primary)
                 }
             }


### PR DESCRIPTION
- add deletion alert protocols that stores alert presentation data to control deletion alert presentation
- expand the deletion alert protocols by implementing the alert presentation logic to remove code repetition
- add static alert message constants to remove code repetition
- change the logic of the screens with the card deletion action to make them display an alert before deleting the card
- add an alert that shows a warning before the user performs any important action to protect him from unintended actions